### PR TITLE
Reworked LaTeX symbol lookup & minor visual overhaul

### DIFF
--- a/convert.js
+++ b/convert.js
@@ -1,40 +1,42 @@
+'use strict'; 
+
 function getText() {
     return document.getElementById("logic").value;
 }
 
+const LatexDictionary = new Map([
+    ["not", "\\neg"],
+    ["and", "\\wedge"],
+    ["^", "\\wedge"],
+    ["or", "\\vee"],
+    ["v", "\\vee"],
+    ["implies", "\\rightarrow"],
+    ["->", "\\rightarrow"],
+    ["equiv",  "\\;\\equiv\\; &"],
+    ["===", "\\;\\equiv\\; &"],
+    ["<->", "\\iff"],
+    ["E", "\\exists"],
+    ["V", "\\forall"]
+]); 
+
+
 function latexify() {
-    var text;
-    var tokens = new Array();
+    let text;
+    let tokens = new Array();
     getText().split(" ").forEach(s => {
+        let nextToken;
+
         if (s != "" || s != " ") {
             s = s.includes("\n") ? s.replace("\n", "\\\\\n\\;\\equiv\\; & ") : s;
             s = s.includes("[") ? "&& ".concat("", s) : s;
             s = s.includes("!") ? s.replace("!", "\\neg ") : s;
-            switch(s) {
-                case "not":
-                    x = "\\neg";
-                    break;
-                case "and":
-                case "^":
-                    x = "\\wedge";
-                    break;
-                case "or":
-                case "v":
-                    x = "\\vee";
-                    break;
-                case "implies":
-                case "->":
-                    x = "\\rightarrow";
-                    break;
-                case "equiv":
-                case "===":
-                    x = "\\;\\equiv\\; &";
-                    break;
-                default:
-                    x = s;
-            }
+
+            // Use map as look-up table for respective latex code 
+            const latexCode = LatexDictionary.get(s);
+            nextToken = (latexCode) ? latexCode : s; 
+            
         }
-        tokens.push(x);
+        tokens.push(nextToken);
     });
     
     text = "\\begin{align*}\n".concat("", tokens[0]);

--- a/style.css
+++ b/style.css
@@ -5,12 +5,14 @@ html {
     height: 100%;
 }
 
+
 body {
     text-align: center;
     font-family: -apple-system, system-ui, BlinkMacSystemFont, "Segoe UI", "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
     background-repeat: no-repeat;
     background: rgb(0,0,0);
     background: linear-gradient(160deg, rgba(0,0,0,1) 0%, rgba(106,9,125,1) 69%, rgba(192,96,161,1) 100%);
+    background-attachment: fixed; /*Makes the gradient continuous along the entire page*/
     color: #ffffff;
 }
 


### PR DESCRIPTION
Hello Noah!

I had some downtime so I decided to start making some PRs on people's repositories for Hacktoberfest.

I made a few modifications to your website code which I think could help make this project more scalable for the addition of more logic symbols.  Feel free to deny the PR and/or request changes to it.

## **Overview of Changes:**
### 1. Addition of "Map" over switch/case & added more pseudo-english keywords
I swapped out your switch/case statement block in favor of a dictionary data-structure in the form of JavaScript's built-in [```Map```](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) object.  

My rationale for this being that a dictionary will more easily allow for adding more pseudo-English keywords to translate into latex down the line if you ever want to add more symbols (especially if you ever add all the set theory symbols).

Now the pseudo-english keywords are listed as "keys" with corresponding LaTeX as the "value".

Here's what the dictionary looks like:
```
const LatexDictionary = new Map([
    ["not", "\\neg"],
    ["and", "\\wedge"],
    ["^", "\\wedge"],
    ["or", "\\vee"],
    ["v", "\\vee"],
    ["implies", "\\rightarrow"],
    ["->", "\\rightarrow"],
    ["equiv",  "\\;\\equiv\\; &"],
    ["===", "\\;\\equiv\\; &"],
    ["<->", "\\iff"],
    ["E", "\\exists"],
    ["V", "\\forall"]
]); 
```

And the switch/case code has now been replaced by a few lines which perform a dictionary look-up:

```
            ... 
            const latexCode = LatexDictionary.get(s);
            nextToken = (latexCode) ? latexCode : s; 
            ...
```

Finally, I also added a few new pseudo-english keywords for a couple more prepositional logic symbols: the existential quantifier as "E", the universal quantifier as "V" and the double arrow "<->" for the "if and only if" statement.

 ### 2. Small CSS tweak to make linear-gradient take up the whole screen on small displays.

By adding the line ```background-attachment: fixed;``` I made the linear-gradient background encompass the whole screen rather than repeat into rough blocks on smaller screens.

I have two screenshots showing the before & after of this style sheet to showcase this change:

#### Before style-sheet change (gradient repeats):
![image of a linear gradient repeating](https://i.imgur.com/C1yTm4z.png)

#### After style-sheet change (gradient stays continuous):
![image of a linear gradient not repeating](https://i.imgur.com/vra85tS.png)